### PR TITLE
fix: update reserve info schema

### DIFF
--- a/src/market.ts
+++ b/src/market.ts
@@ -25,10 +25,14 @@ import { MarketReserveInfoStructList, PositionInfoStructList } from "./layout"
 import type { ObligationAccount } from "./types"
 
 export interface JetMarketReserveInfo {
-  address: PublicKey
+  reserve: PublicKey
   price: anchor.BN
   depositNoteExchangeRate: anchor.BN
   loanNoteExchangeRate: anchor.BN
+  minCollateralRatio: anchor.BN
+  liquidationBonus: anchor.BN
+  lastUpdated: anchor.BN
+  invalidated: anchor.BN
 }
 
 export interface JetMarketData {

--- a/src/user.ts
+++ b/src/user.ts
@@ -829,7 +829,7 @@ export class JetUser implements User {
     this._collateral = []
 
     for (const reserve of this.market.reserves) {
-      if (reserve.address.equals(PublicKey.default)) {
+      if (reserve.reserve.equals(PublicKey.default)) {
         continue
       }
 
@@ -886,7 +886,7 @@ export class JetUser implements User {
    * @memberof JetUser
    */
   private async findReserveAccounts(reserve: JetMarketReserveInfo | JetReserve): Promise<UserReserveAccounts> {
-    const reserveAddress = (reserve as any).address ?? (reserve as any).data.address
+    const reserveAddress = (reserve as any).reserve ?? (reserve as any).data?.address
 
     const deposits = await this.client.findDerivedAccount(["deposits", (reserve as any).address, this.address])
     const loan = await this.client.findDerivedAccount(["loan", reserveAddress, this.obligation.address, this.address])


### PR DESCRIPTION
i think `JetMarketReserveInfo`'s schema has changed?


```json
 {
    reserve: PublicKey { _bn: <BN: 0> },
    _UNUSED_0_: <Buffer 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ... 30 more bytes>,
    price: <BN: 0>,
    depositNoteExchangeRate: <BN: 0>,
    loanNoteExchangeRate: <BN: 0>,
    minCollateralRatio: <BN: 0>,
    liquidationBonus: 0,
    _UNUSED_1_: <Buffer 00 00 00 00 00 00 00>,
    lastUpdated: <BN: 0>,
    invalidated: 0
  }
```