### PR TITLE
precomit build

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "fmt:fix": "prettier src/ tests/ types/ --write",
     "lint": "eslint src/ --ext .ts",
     "test": "jest",
-    "precommit": "npm run fmt:fix && npm run lint",
+    "precommit": "npm run build && npm run fmt:fix && npm run lint",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
I noticed there was a PR where a import wasn't used and it couldn't compile

This will stop that from happening most of the time