### PR TITLE
revert unbonding account from shares to tokens

### DIFF
--- a/src/staking/unbondingAccount.ts
+++ b/src/staking/unbondingAccount.ts
@@ -34,8 +34,8 @@ export interface UnbondingAmount {
 export class UnbondingAccount {
   private static readonly UINT32_MAXVALUE = 2 ** 32
 
-  /** The total amount of shares unbonding */
-  public shares: BN = new BN(0)
+  /** The total amount of tokens unbonding */
+  public tokens: BN = new BN(0)
 
   /**
    * TODO:
@@ -125,7 +125,7 @@ export class UnbondingAccount {
     public address: PublicKey,
     public unbondingAccount: UnbondingAccountInfo
   ) {
-    this.shares = new BN(0)
+    this.tokens = new BN(0)
   }
 
   /**


### PR DESCRIPTION
`UnbondingAccountInfo` has `shares`, `UnbondingAccount` Class should have `tokens` to keep track of the amount of tokens the shares' worth